### PR TITLE
#13 - Update SSH_SK_VERSION_MAJOR from 7 to 9

### DIFF
--- a/src/sk-api.h
+++ b/src/sk-api.h
@@ -74,7 +74,7 @@ struct sk_option {
 	uint8_t required;
 };
 
-#define SSH_SK_VERSION_MAJOR		0x00070000 /* current API version */
+#define SSH_SK_VERSION_MAJOR		0x00090000 /* current API version */
 #define SSH_SK_VERSION_MAJOR_MASK	0xffff0000
 
 /* Return the version of the middleware API */

--- a/src/sk-api.h
+++ b/src/sk-api.h
@@ -1,4 +1,4 @@
-/* $OpenBSD: sk-api.h,v 1.11 2020/09/09 03:08:01 djm Exp $ */
+/* $OpenBSD: sk-api.h,v 1.14 2021/11/02 22:56:40 djm Exp $ */
 /*
  * Copyright (c) 2019 Google LLC
  *
@@ -39,6 +39,7 @@
 #define SSH_SK_ERR_DEVICE_NOT_FOUND	-4
 
 struct sk_enroll_response {
+	uint8_t flags;
 	uint8_t *public_key;
 	size_t public_key_len;
 	uint8_t *key_handle;
@@ -66,6 +67,8 @@ struct sk_resident_key {
 	char *application;
 	struct sk_enroll_response key;
 	uint8_t flags;
+	uint8_t *user_id;
+	size_t user_id_len;
 };
 
 struct sk_option {
@@ -86,7 +89,7 @@ int sk_enroll(uint32_t alg, const uint8_t *challenge, size_t challenge_len,
     struct sk_option **options, struct sk_enroll_response **enroll_response);
 
 /* Sign a challenge */
-int sk_sign(uint32_t alg, const uint8_t *message, size_t message_len,
+int sk_sign(uint32_t alg, const uint8_t *data, size_t data_len,
     const char *application, const uint8_t *key_handle, size_t key_handle_len,
     uint8_t flags, const char *pin, struct sk_option **options,
     struct sk_sign_response **sign_response);

--- a/src/webauthn/webauthn.h
+++ b/src/webauthn/webauthn.h
@@ -72,7 +72,31 @@ extern "C" {
 //          - WEBAUTHN_EXTENSIONS_IDENTIFIER_CRED_PROTECT
 //
 
-#define WEBAUTHN_API_CURRENT_VERSION    WEBAUTHN_API_VERSION_2
+#define WEBAUTHN_API_VERSION_3          3
+// WEBAUTHN_API_VERSION_3 : Delta From WEBAUTHN_API_VERSION_2
+//      Data Structures and their sub versions:
+//          - WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS    :   4
+//          - WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS      :   5
+//          - WEBAUTHN_CREDENTIAL_ATTESTATION                   :   4
+//          - WEBAUTHN_ASSERTION                                :   2
+//      Added Extensions:
+//          - WEBAUTHN_EXTENSIONS_IDENTIFIER_CRED_BLOB
+//          - WEBAUTHN_EXTENSIONS_IDENTIFIER_MIN_PIN_LENGTH
+//
+
+#define WEBAUTHN_API_VERSION_4          4
+// WEBAUTHN_API_VERSION_4 : Delta From WEBAUTHN_API_VERSION_3
+//      Data Structures and their sub versions:
+//          - WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS    :   5
+//          - WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS      :   6
+//          - WEBAUTHN_ASSERTION                                :   3
+//      APIs:
+//          - WebAuthNGetPlatformCredentialList
+//          - WebAuthNFreePlatformCredentialList
+//          - WebAuthNDeletePlatformCredential
+//
+
+#define WEBAUTHN_API_CURRENT_VERSION    WEBAUTHN_API_VERSION_4
 
 //+------------------------------------------------------------------------------------------
 // Information about an RP Entity
@@ -261,6 +285,101 @@ typedef struct _WEBAUTHN_CREDENTIAL_LIST {
 typedef const WEBAUTHN_CREDENTIAL_LIST *PCWEBAUTHN_CREDENTIAL_LIST;
 
 //+------------------------------------------------------------------------------------------
+// Credential Information for WebAuthNGetPlatformCredentialList API
+//-------------------------------------------------------------------------------------------
+
+#define WEBAUTHN_CREDENTIAL_DETAILS_VERSION_1           1
+#define WEBAUTHN_CREDENTIAL_DETAILS_CURRENT_VERSION     WEBAUTHN_CREDENTIAL_DETAILS_VERSION_1
+
+typedef struct _WEBAUTHN_CREDENTIAL_DETAILS {
+    // Version of this structure, to allow for modifications in the future.
+    DWORD dwVersion;
+
+    // Size of pbCredentialID.
+    DWORD cbCredentialID;
+    _Field_size_bytes_(cbCredentialID)
+    PBYTE pbCredentialID;
+
+    // RP Info
+    PWEBAUTHN_RP_ENTITY_INFORMATION     pRpInformation;
+
+    // User Info
+    PWEBAUTHN_USER_ENTITY_INFORMATION   pUserInformation;
+
+    // Removable or not.
+    BOOL bRemovable;
+} WEBAUTHN_CREDENTIAL_DETAILS, *PWEBAUTHN_CREDENTIAL_DETAILS;
+typedef const WEBAUTHN_CREDENTIAL_DETAILS *PCWEBAUTHN_CREDENTIAL_DETAILS;
+
+typedef struct _WEBAUTHN_CREDENTIAL_DETAILS_LIST {
+    DWORD cCredentialDetails;
+    _Field_size_(cCredentialDetails)
+    PWEBAUTHN_CREDENTIAL_DETAILS *ppCredentialDetails;
+} WEBAUTHN_CREDENTIAL_DETAILS_LIST, *PWEBAUTHN_CREDENTIAL_DETAILS_LIST;
+typedef const WEBAUTHN_CREDENTIAL_DETAILS_LIST *PCWEBAUTHN_CREDENTIAL_DETAILS_LIST;
+
+#define WEBAUTHN_GET_CREDENTIALS_OPTIONS_VERSION_1          1
+#define WEBAUTHN_GET_CREDENTIALS_OPTIONS_CURRENT_VERSION    WEBAUTHN_GET_CREDENTIALS_OPTIONS_VERSION_1
+
+typedef struct _WEBAUTHN_GET_CREDENTIALS_OPTIONS {
+    // Version of this structure, to allow for modifications in the future.
+    DWORD dwVersion;
+
+    // Optional.
+    LPCWSTR pwszRpId;
+
+    // Optional. BrowserInPrivate Mode. Defaulting to FALSE.
+    BOOL bBrowserInPrivateMode;
+} WEBAUTHN_GET_CREDENTIALS_OPTIONS, *PWEBAUTHN_GET_CREDENTIALS_OPTIONS;
+typedef const WEBAUTHN_GET_CREDENTIALS_OPTIONS *PCWEBAUTHN_GET_CREDENTIALS_OPTIONS;
+
+//+------------------------------------------------------------------------------------------
+// PRF values.
+//-------------------------------------------------------------------------------------------
+
+#define WEBAUTHN_CTAP_ONE_HMAC_SECRET_LENGTH    32
+
+// SALT values below by default are converted into RAW Hmac-Secret values as per PRF extension.
+//   - SHA-256(UTF8Encode("WebAuthn PRF") || 0x00 || Value)
+//
+// Set WEBAUTHN_AUTHENTICATOR_HMAC_SECRET_VALUES_FLAG in dwFlags in WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS,
+//   if caller wants to provide RAW Hmac-Secret SALT values directly. In that case,
+//   values if provided MUST be of WEBAUTHN_CTAP_ONE_HMAC_SECRET_LENGTH size.
+
+typedef struct _WEBAUTHN_HMAC_SECRET_SALT {
+    // Size of pbFirst.
+    DWORD cbFirst;
+    _Field_size_bytes_(cbFirst)
+    PBYTE pbFirst;                                  // Required
+
+    // Size of pbSecond.
+    DWORD cbSecond;
+    _Field_size_bytes_(cbSecond)
+    PBYTE pbSecond;
+} WEBAUTHN_HMAC_SECRET_SALT, *PWEBAUTHN_HMAC_SECRET_SALT;
+typedef const WEBAUTHN_HMAC_SECRET_SALT *PCWEBAUTHN_HMAC_SECRET_SALT;
+
+typedef struct _WEBAUTHN_CRED_WITH_HMAC_SECRET_SALT {
+    // Size of pbCredID.
+    DWORD cbCredID;
+    _Field_size_bytes_(cbCredID)
+    PBYTE pbCredID;                                 // Required
+
+    // PRF Values for above credential
+    PWEBAUTHN_HMAC_SECRET_SALT pHmacSecretSalt;     // Required
+} WEBAUTHN_CRED_WITH_HMAC_SECRET_SALT, *PWEBAUTHN_CRED_WITH_HMAC_SECRET_SALT;
+typedef const WEBAUTHN_CRED_WITH_HMAC_SECRET_SALT *PCWEBAUTHN_CRED_WITH_HMAC_SECRET_SALT;
+
+typedef struct _WEBAUTHN_HMAC_SECRET_SALT_VALUES {
+    PWEBAUTHN_HMAC_SECRET_SALT pGlobalHmacSalt;
+
+    DWORD cCredWithHmacSecretSaltList;
+    _Field_size_(cCredWithHmacSecretSaltList)
+    PWEBAUTHN_CRED_WITH_HMAC_SECRET_SALT pCredWithHmacSecretSaltList;
+} WEBAUTHN_HMAC_SECRET_SALT_VALUES, *PWEBAUTHN_HMAC_SECRET_SALT_VALUES;
+typedef const WEBAUTHN_HMAC_SECRET_SALT_VALUES *PCWEBAUTHN_HMAC_SECRET_SALT_VALUES;
+
+//+------------------------------------------------------------------------------------------
 // Hmac-Secret extension
 //-------------------------------------------------------------------------------------------
 
@@ -307,6 +426,50 @@ typedef const WEBAUTHN_CRED_PROTECT_EXTENSION_IN *PCWEBAUTHN_CRED_PROTECT_EXTENS
 // GetAssertion Output Type:    Not Supported
 
 //+------------------------------------------------------------------------------------------
+//  credBlob  extension
+//-------------------------------------------------------------------------------------------
+
+typedef struct _WEBAUTHN_CRED_BLOB_EXTENSION {
+    // Size of pbCredBlob.
+    DWORD cbCredBlob;
+    _Field_size_bytes_(cbCredBlob)
+    PBYTE pbCredBlob;
+} WEBAUTHN_CRED_BLOB_EXTENSION, *PWEBAUTHN_CRED_BLOB_EXTENSION;
+typedef const WEBAUTHN_CRED_BLOB_EXTENSION *PCWEBAUTHN_CRED_BLOB_EXTENSION;
+
+
+#define WEBAUTHN_EXTENSIONS_IDENTIFIER_CRED_BLOB                 L"credBlob"
+// Below type definitions is for WEBAUTHN_EXTENSIONS_IDENTIFIER_CRED_BLOB
+// MakeCredential Input Type:   WEBAUTHN_CRED_BLOB_EXTENSION.
+//      - pvExtension must point to a WEBAUTHN_CRED_BLOB_EXTENSION struct
+//      - cbExtension must contain the sizeof(WEBAUTHN_CRED_BLOB_EXTENSION).
+// MakeCredential Output Type:  BOOL.
+//      - pvExtension will point to a BOOL with the value TRUE if credBlob was successfully created
+//      - cbExtension will contain the sizeof(BOOL).
+// GetAssertion Input Type:     BOOL.
+//      - pvExtension must point to a BOOL with the value TRUE to request the credBlob.
+//      - cbExtension must contain the sizeof(BOOL).
+// GetAssertion Output Type:    WEBAUTHN_CRED_BLOB_EXTENSION.
+//      - pvExtension will point to a WEBAUTHN_CRED_BLOB_EXTENSION struct if the authenticator
+//        returns the credBlob in the signed extensions
+//      - cbExtension will contain the sizeof(WEBAUTHN_CRED_BLOB_EXTENSION).
+
+//+------------------------------------------------------------------------------------------
+//  minPinLength  extension
+//-------------------------------------------------------------------------------------------
+
+#define WEBAUTHN_EXTENSIONS_IDENTIFIER_MIN_PIN_LENGTH                 L"minPinLength"
+// Below type definitions is for WEBAUTHN_EXTENSIONS_IDENTIFIER_MIN_PIN_LENGTH
+// MakeCredential Input Type:   BOOL.
+//      - pvExtension must point to a BOOL with the value TRUE to request the minPinLength.
+//      - cbExtension must contain the sizeof(BOOL).
+// MakeCredential Output Type:  DWORD.
+//      - pvExtension will point to a DWORD with the minimum pin length if returned by the authenticator
+//      - cbExtension will contain the sizeof(DWORD).
+// GetAssertion Input Type:     Not Supported
+// GetAssertion Output Type:    Not Supported
+
+//+------------------------------------------------------------------------------------------
 // Information about Extensions.
 //-------------------------------------------------------------------------------------------
 typedef struct _WEBAUTHN_EXTENSION {
@@ -342,10 +505,20 @@ typedef const WEBAUTHN_EXTENSIONS *PCWEBAUTHN_EXTENSIONS;
 #define WEBAUTHN_ATTESTATION_CONVEYANCE_PREFERENCE_INDIRECT                 2
 #define WEBAUTHN_ATTESTATION_CONVEYANCE_PREFERENCE_DIRECT                   3
 
+#define WEBAUTHN_ENTERPRISE_ATTESTATION_NONE                                0
+#define WEBAUTHN_ENTERPRISE_ATTESTATION_VENDOR_FACILITATED                  1
+#define WEBAUTHN_ENTERPRISE_ATTESTATION_PLATFORM_MANAGED                    2
+
+#define WEBAUTHN_LARGE_BLOB_SUPPORT_NONE                                    0
+#define WEBAUTHN_LARGE_BLOB_SUPPORT_REQUIRED                                1
+#define WEBAUTHN_LARGE_BLOB_SUPPORT_PREFERRED                               2
+
 #define WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS_VERSION_1            1
 #define WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS_VERSION_2            2
 #define WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS_VERSION_3            3
-#define WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS_CURRENT_VERSION      WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS_VERSION_3
+#define WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS_VERSION_4            4
+#define WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS_VERSION_5            5
+#define WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS_CURRENT_VERSION      WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS_VERSION_5
 
 typedef struct _WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS {
     // Version of this structure, to allow for modifications in the future.
@@ -364,7 +537,7 @@ typedef struct _WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS {
     // Optional. Platform vs Cross-Platform Authenticators.
     DWORD dwAuthenticatorAttachment;
 
-    // Optional. Require key to be resident or not. Defaulting to FALSE;
+    // Optional. Require key to be resident or not. Defaulting to FALSE.
     BOOL bRequireResidentKey;
 
     // User Verification Requirement.
@@ -390,15 +563,51 @@ typedef struct _WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS {
     // Exclude Credential List. If present, "CredentialList" will be ignored.
     PWEBAUTHN_CREDENTIAL_LIST pExcludeCredentialList;
 
+    //
+    // The following fields have been added in WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS_VERSION_4
+    //
+
+    // Enterprise Attestation
+    DWORD dwEnterpriseAttestation;
+
+    // Large Blob Support: none, required or preferred
+    //
+    // NTE_INVALID_PARAMETER when large blob required or preferred and
+    //   bRequireResidentKey isn't set to TRUE
+    DWORD dwLargeBlobSupport;
+
+    // Optional. Prefer key to be resident. Defaulting to FALSE. When TRUE,
+    // overrides the above bRequireResidentKey.
+    BOOL bPreferResidentKey;
+
+    //
+    // The following fields have been added in WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS_VERSION_5
+    //
+
+    // Optional. BrowserInPrivate Mode. Defaulting to FALSE.
+    BOOL bBrowserInPrivateMode;
+
 } WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS, *PWEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS;
 typedef const WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS *PCWEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS;
 
+#define WEBAUTHN_CRED_LARGE_BLOB_OPERATION_NONE         0
+#define WEBAUTHN_CRED_LARGE_BLOB_OPERATION_GET          1
+#define WEBAUTHN_CRED_LARGE_BLOB_OPERATION_SET          2
+#define WEBAUTHN_CRED_LARGE_BLOB_OPERATION_DELETE       3
 
 #define WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS_VERSION_1          1
 #define WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS_VERSION_2          2
 #define WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS_VERSION_3          3
 #define WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS_VERSION_4          4
-#define WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS_CURRENT_VERSION    WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS_VERSION_4
+#define WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS_VERSION_5          5
+#define WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS_VERSION_6          6
+#define WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS_CURRENT_VERSION    WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS_VERSION_6
+
+/*
+    Information about flags.
+*/
+
+#define WEBAUTHN_AUTHENTICATOR_HMAC_SECRET_VALUES_FLAG   0x00100000
 
 typedef struct _WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS {
     // Version of this structure, to allow for modifications in the future.
@@ -420,7 +629,7 @@ typedef struct _WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS {
     // User Verification Requirement.
     DWORD dwUserVerificationRequirement;
 
-    // Reserved for future Use
+    // Flags
     DWORD dwFlags;
 
     //
@@ -447,6 +656,27 @@ typedef struct _WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS {
 
     // Allow Credential List. If present, "CredentialList" will be ignored.
     PWEBAUTHN_CREDENTIAL_LIST pAllowCredentialList;
+
+    //
+    // The following fields have been added in WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS_VERSION_5
+    //
+
+    DWORD dwCredLargeBlobOperation;
+
+    // Size of pbCredLargeBlob
+    DWORD cbCredLargeBlob;
+    _Field_size_bytes_(cbCredLargeBlob)
+    PBYTE pbCredLargeBlob;
+
+    //
+    // The following fields have been added in WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS_VERSION_6
+    //
+
+    // PRF values which will be converted into HMAC-SECRET values according to WebAuthn Spec.
+    PWEBAUTHN_HMAC_SECRET_SALT_VALUES pHmacSecretSaltValues;
+
+    // Optional. BrowserInPrivate Mode. Defaulting to FALSE.
+    BOOL bBrowserInPrivateMode;
 
 } WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS,  *PWEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS;
 typedef const WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS  *PCWEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS;
@@ -523,7 +753,8 @@ typedef const WEBAUTHN_COMMON_ATTESTATION *PCWEBAUTHN_COMMON_ATTESTATION;
 #define WEBAUTHN_CREDENTIAL_ATTESTATION_VERSION_1               1
 #define WEBAUTHN_CREDENTIAL_ATTESTATION_VERSION_2               2
 #define WEBAUTHN_CREDENTIAL_ATTESTATION_VERSION_3               3
-#define WEBAUTHN_CREDENTIAL_ATTESTATION_CURRENT_VERSION         WEBAUTHN_CREDENTIAL_ATTESTATION_VERSION_3
+#define WEBAUTHN_CREDENTIAL_ATTESTATION_VERSION_4               4
+#define WEBAUTHN_CREDENTIAL_ATTESTATION_CURRENT_VERSION         WEBAUTHN_CREDENTIAL_ATTESTATION_VERSION_4
 
 typedef struct _WEBAUTHN_CREDENTIAL_ATTESTATION {
     // Version of this structure, to allow for modifications in the future.
@@ -578,6 +809,14 @@ typedef struct _WEBAUTHN_CREDENTIAL_ATTESTATION {
     // the transport that was used.
     DWORD dwUsedTransport;
 
+    //
+    // Following fields have been added in WEBAUTHN_CREDENTIAL_ATTESTATION_VERSION_4
+    //
+
+    BOOL bEpAtt;
+    BOOL bLargeBlobSupported;
+    BOOL bResidentKey;
+
 } WEBAUTHN_CREDENTIAL_ATTESTATION, *PWEBAUTHN_CREDENTIAL_ATTESTATION;
 typedef const WEBAUTHN_CREDENTIAL_ATTESTATION *PCWEBAUTHN_CREDENTIAL_ATTESTATION;
 
@@ -586,7 +825,21 @@ typedef const WEBAUTHN_CREDENTIAL_ATTESTATION *PCWEBAUTHN_CREDENTIAL_ATTESTATION
 // authenticatorGetAssertion output.
 //-------------------------------------------------------------------------------------------
 
-#define WEBAUTHN_ASSERTION_CURRENT_VERSION                              1
+#define WEBAUTHN_CRED_LARGE_BLOB_STATUS_NONE                    0
+#define WEBAUTHN_CRED_LARGE_BLOB_STATUS_SUCCESS                 1
+#define WEBAUTHN_CRED_LARGE_BLOB_STATUS_NOT_SUPPORTED           2
+#define WEBAUTHN_CRED_LARGE_BLOB_STATUS_INVALID_DATA            3
+#define WEBAUTHN_CRED_LARGE_BLOB_STATUS_INVALID_PARAMETER       4
+#define WEBAUTHN_CRED_LARGE_BLOB_STATUS_NOT_FOUND               5
+#define WEBAUTHN_CRED_LARGE_BLOB_STATUS_MULTIPLE_CREDENTIALS    6
+#define WEBAUTHN_CRED_LARGE_BLOB_STATUS_LACK_OF_SPACE           7
+#define WEBAUTHN_CRED_LARGE_BLOB_STATUS_PLATFORM_ERROR          8
+#define WEBAUTHN_CRED_LARGE_BLOB_STATUS_AUTHENTICATOR_ERROR     9
+
+#define WEBAUTHN_ASSERTION_VERSION_1                            1
+#define WEBAUTHN_ASSERTION_VERSION_2                            2
+#define WEBAUTHN_ASSERTION_VERSION_3                            3
+#define WEBAUTHN_ASSERTION_CURRENT_VERSION                      WEBAUTHN_ASSERTION_VERSION_3
 
 typedef struct _WEBAUTHN_ASSERTION {
     // Version of this structure, to allow for modifications in the future.
@@ -612,6 +865,26 @@ typedef struct _WEBAUTHN_ASSERTION {
     // UserId
     _Field_size_bytes_(cbUserId)
     PBYTE pbUserId;
+
+    //
+    // Following fields have been added in WEBAUTHN_ASSERTION_VERSION_2
+    //
+
+    WEBAUTHN_EXTENSIONS Extensions;
+
+    // Size of pbCredLargeBlob
+    DWORD cbCredLargeBlob;
+    _Field_size_bytes_(cbCredLargeBlob)
+    PBYTE pbCredLargeBlob;
+
+    DWORD dwCredLargeBlobStatus;
+
+    //
+    // Following fields have been added in WEBAUTHN_ASSERTION_VERSION_3
+    //
+
+    PWEBAUTHN_HMAC_SECRET_SALT pHmacSecret;
+
 } WEBAUTHN_ASSERTION, *PWEBAUTHN_ASSERTION;
 typedef const WEBAUTHN_ASSERTION *PCWEBAUTHN_ASSERTION;
 
@@ -669,6 +942,25 @@ HRESULT
 WINAPI
 WebAuthNCancelCurrentOperation(
     _In_ const GUID* pCancellationId);
+
+// Returns NTE_NOT_FOUND when credentials are not found.
+HRESULT
+WINAPI
+WebAuthNGetPlatformCredentialList(
+    _In_    PCWEBAUTHN_GET_CREDENTIALS_OPTIONS                  pGetCredentialsOptions,
+    _Outptr_result_maybenull_ PWEBAUTHN_CREDENTIAL_DETAILS_LIST *ppCredentialDetailsList);
+
+void
+WINAPI
+WebAuthNFreePlatformCredentialList(
+    _In_ PWEBAUTHN_CREDENTIAL_DETAILS_LIST  pCredentialDetailsList);
+
+HRESULT
+WINAPI
+WebAuthNDeletePlatformCredential(
+    _In_ DWORD cbCredentialId,
+    _In_reads_bytes_(cbCredentialId) const BYTE *pbCredentialId
+    );
 
 //
 // Returns the following Error Names:

--- a/src/winhello.c
+++ b/src/winhello.c
@@ -477,7 +477,7 @@ static int pack_sig(uint32_t alg, BYTE *sign, size_t len, struct sk_sign_respons
 }
 
 /* Sign a challenge */
-int sk_sign(uint32_t alg, const uint8_t *message, size_t message_len, const char *application, const uint8_t *key_handle, size_t key_handle_len, uint8_t flags, const char *pin, struct sk_option **options, struct sk_sign_response **sign_response)
+int sk_sign(uint32_t alg, const uint8_t *data, size_t data_len, const char *application, const uint8_t *key_handle, size_t key_handle_len, uint8_t flags, const char *pin, struct sk_option **options, struct sk_sign_response **sign_response)
 {
 	struct sk_sign_response *response = NULL;
 	int ret = SSH_SK_ERR_GENERAL;
@@ -515,7 +515,7 @@ int sk_sign(uint32_t alg, const uint8_t *message, size_t message_len, const char
 		goto out;
 	}
 
-	WEBAUTHN_CLIENT_DATA WebAuthNClientData = {WEBAUTHN_CLIENT_DATA_CURRENT_VERSION, message_len, (uint8_t *)message, WEBAUTHN_HASH_ALGORITHM_SHA_256};
+	WEBAUTHN_CLIENT_DATA WebAuthNClientData = {WEBAUTHN_CLIENT_DATA_CURRENT_VERSION, data_len, (uint8_t *)data, WEBAUTHN_HASH_ALGORITHM_SHA_256};
 
 	BOOL pbU2fAppId = FALSE;
 	WEBAUTHN_CREDENTIAL credential = {WEBAUTHN_CREDENTIAL_CURRENT_VERSION, key_handle_len, (uint8_t *)key_handle, WEBAUTHN_CREDENTIAL_TYPE_PUBLIC_KEY};


### PR DESCRIPTION
Addressing [issue 13](https://github.com/tavrez/openssh-sk-winhello/issues/13), I copied this version of `sk-api.h` and changed a couple variables to match the names within (from message to data).

After that, I was able to create a key against `Openssh_9.0p1, OpenSSL 1.1.1q  Jul 5 2022` using my yubikey + windows hello.

By bumping from 7 to 9, we'll notably be missing support for 8 and a. See mentions of `SSH_SK_VERSION_MAJOR` in the [OpenSSH release notes](https://www.openssh.com/releasenotes.html), and these [commits](https://github.com/openssh/openssh-portable/commits/9ab929ca2d820520327b41929372bcb9e261534c/sk-api.h) that edit the `sk-api.h` file.